### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ms-azuretools/534e1e1c-b364-44d0-b5ee-dce879a5106e/7f0b53d0-1055-4e28-ae51-d871f726dc15/_apis/work/boardbadge/c0149f01-2b4a-43b7-86e4-408c572b0c05)](https://dev.azure.com/ms-azuretools/534e1e1c-b364-44d0-b5ee-dce879a5106e/_boards/board/t/7f0b53d0-1055-4e28-ae51-d871f726dc15/Microsoft.RequirementCategory)
 "# template-examples" 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ms-azuretools/534e1e1c-b364-44d0-b5ee-dce879a5106e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.